### PR TITLE
v5 Release of Polly wrapper

### DIFF
--- a/.github/workflows/publish_nuget_package.yml
+++ b/.github/workflows/publish_nuget_package.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '10.x'
 
       - name: Clear NuGet Cache
         run: dotnet nuget locals all --clear

--- a/.gitignore
+++ b/.gitignore
@@ -103,11 +103,6 @@ _TeamCity*
 # DotCover is a Code Coverage Tool
 *.dotCover
 
-# NCrunch
-_NCrunch_*
-.*crunch*.local.xml
-*.v3.ncrunchsolution.user
-
 # MightyMoose
 *.mm.*
 AutoTest.Net/

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ For full API documentation, please visit [evidos.github.io](https://evidos.githu
 For detailed examples, visit: [https://github.com/Evidos/SignhostClientLibrary/blob/master/README.md](https://github.com/Evidos/SignhostClientLibrary/blob/master/README.md)
 
 ```c#
-var settings = new SignHostApiClientSettings("YourAppKey", "apikey or usertoken");
+var settings = new SignhostApiClientSettings("YourAppKey", "apikey or usertoken");
 
-var retryClient = new SignHostApiRetryClient(settings);
-
+var retryClient = new SignhostApiRetryClient(settings);
 ```

--- a/src/Signhost.APIClient.Tests/Signhost.APIClient.Tests.csproj
+++ b/src/Signhost.APIClient.Tests/Signhost.APIClient.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup Label="Build">
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/src/Signhost.APIClient.Tests/Signhost.APIClient.Tests.csproj
+++ b/src/Signhost.APIClient.Tests/Signhost.APIClient.Tests.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup Label="Build">
 		<TargetFramework>net10.0</TargetFramework>
 		<IsPackable>false</IsPackable>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup Label="Package References">

--- a/src/Signhost.APIClient.Tests/SignhostApiRetryClientTests.cs
+++ b/src/Signhost.APIClient.Tests/SignhostApiRetryClientTests.cs
@@ -17,16 +17,16 @@ using Xunit;
 namespace SignhostAPIRetryClient.Tests
 {
 	/// <summary>
-	/// Tests the SignHostApiRetryClient.
+	/// Tests the SignhostApiRetryClient.
 	/// </summary>
 	public class SignhostApiRetryClientTests
 		: IDisposable
 	{
-		private readonly SignHostApiClientSettings settings;
+		private readonly SignhostApiClientSettings settings;
 
-		private readonly SignHostApiRetryClient firstCallSucceedsClient;
-		private readonly SignHostApiRetryClient thirdCallSucceedsClient;
-		private readonly SignHostApiRetryClient allCallsFailClient;
+		private readonly SignhostApiRetryClient firstCallSucceedsClient;
+		private readonly SignhostApiRetryClient thirdCallSucceedsClient;
+		private readonly SignhostApiRetryClient allCallsFailClient;
 
 		private readonly MemoryStream documentFile;
 
@@ -36,12 +36,12 @@ namespace SignhostAPIRetryClient.Tests
 		/// </summary>
 		public SignhostApiRetryClientTests()
 		{
-			settings = new SignHostApiClientSettings(
+			settings = new SignhostApiClientSettings(
 				"AppKey") {
 				Endpoint = "http://localhost/api/",
 			};
 
-			firstCallSucceedsClient = new SignHostApiRetryClient(
+			firstCallSucceedsClient = new SignhostApiRetryClient(
 				settings,
 				new HttpClient(
 					SetupMockedHandler(
@@ -50,7 +50,7 @@ namespace SignhostAPIRetryClient.Tests
 						HttpStatusCode.InternalServerError,
 						HttpStatusCode.InternalServerError)));
 
-			thirdCallSucceedsClient = new SignHostApiRetryClient(
+			thirdCallSucceedsClient = new SignhostApiRetryClient(
 				settings,
 				new HttpClient(
 					SetupMockedHandler(
@@ -59,7 +59,7 @@ namespace SignhostAPIRetryClient.Tests
 						HttpStatusCode.OK,
 						HttpStatusCode.InternalServerError)));
 
-			allCallsFailClient = new SignHostApiRetryClient(
+			allCallsFailClient = new SignhostApiRetryClient(
 				settings,
 				new HttpClient(
 					SetupMockedHandler(

--- a/src/Signhost.APIClient.Tests/SignhostApiRetryClientTests.cs
+++ b/src/Signhost.APIClient.Tests/SignhostApiRetryClientTests.cs
@@ -14,425 +14,424 @@ using Signhost.APIClient.Rest.ErrorHandling;
 using Signhost.APIClient.Rest.Polly;
 using Xunit;
 
-namespace SignhostAPIRetryClient.Tests
+namespace SignhostAPIRetryClient.Tests;
+
+/// <summary>
+/// Tests the SignhostApiRetryClient.
+/// </summary>
+public class SignhostApiRetryClientTests
+	: IDisposable
 {
+	private readonly SignhostApiClientSettings settings;
+
+	private readonly SignhostApiRetryClient firstCallSucceedsClient;
+	private readonly SignhostApiRetryClient thirdCallSucceedsClient;
+	private readonly SignhostApiRetryClient allCallsFailClient;
+
+	private readonly MemoryStream documentFile;
+
 	/// <summary>
-	/// Tests the SignhostApiRetryClient.
+	/// Initializes a new instance of the <see cref="SignhostApiRetryClientTests"/> class.
+	/// Sets up the mocked handlers for the HttpClient.
 	/// </summary>
-	public class SignhostApiRetryClientTests
-		: IDisposable
+	public SignhostApiRetryClientTests()
 	{
-		private readonly SignhostApiClientSettings settings;
+		settings = new SignhostApiClientSettings(
+			"AppKey") {
+			Endpoint = "http://localhost/api/",
+		};
 
-		private readonly SignhostApiRetryClient firstCallSucceedsClient;
-		private readonly SignhostApiRetryClient thirdCallSucceedsClient;
-		private readonly SignhostApiRetryClient allCallsFailClient;
+		firstCallSucceedsClient = new SignhostApiRetryClient(
+			settings,
+			new HttpClient(
+				SetupMockedHandler(
+					HttpStatusCode.OK,
+					HttpStatusCode.InternalServerError,
+					HttpStatusCode.InternalServerError,
+					HttpStatusCode.InternalServerError)));
 
-		private readonly MemoryStream documentFile;
+		thirdCallSucceedsClient = new SignhostApiRetryClient(
+			settings,
+			new HttpClient(
+				SetupMockedHandler(
+					HttpStatusCode.InternalServerError,
+					HttpStatusCode.InternalServerError,
+					HttpStatusCode.OK,
+					HttpStatusCode.InternalServerError)));
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="SignhostApiRetryClientTests"/> class.
-		/// Sets up the mocked handlers for the HttpClient.
-		/// </summary>
-		public SignhostApiRetryClientTests()
-		{
-			settings = new SignhostApiClientSettings(
-				"AppKey") {
-				Endpoint = "http://localhost/api/",
-			};
+		allCallsFailClient = new SignhostApiRetryClient(
+			settings,
+			new HttpClient(
+				SetupMockedHandler(
+					HttpStatusCode.InternalServerError,
+					HttpStatusCode.InternalServerError,
+					HttpStatusCode.InternalServerError,
+					HttpStatusCode.InternalServerError)));
 
-			firstCallSucceedsClient = new SignhostApiRetryClient(
-				settings,
-				new HttpClient(
-					SetupMockedHandler(
-						HttpStatusCode.OK,
-						HttpStatusCode.InternalServerError,
-						HttpStatusCode.InternalServerError,
-						HttpStatusCode.InternalServerError)));
+		documentFile = new MemoryStream();
+	}
 
-			thirdCallSucceedsClient = new SignhostApiRetryClient(
-				settings,
-				new HttpClient(
-					SetupMockedHandler(
-						HttpStatusCode.InternalServerError,
-						HttpStatusCode.InternalServerError,
-						HttpStatusCode.OK,
-						HttpStatusCode.InternalServerError)));
+	/// <summary>
+	/// Tests if the api call works as expected the first time around.
+	/// So the retry policy isn't used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_First_Call_Succeeds_AddOrReplaceFileMetaToTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			firstCallSucceedsClient.AddOrReplaceFileMetaToTransactionAsync(
+				new FileMeta(),
+				"Transaction Id",
+				"File Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-			allCallsFailClient = new SignhostApiRetryClient(
-				settings,
-				new HttpClient(
-					SetupMockedHandler(
-						HttpStatusCode.InternalServerError,
-						HttpStatusCode.InternalServerError,
-						HttpStatusCode.InternalServerError,
-						HttpStatusCode.InternalServerError)));
+	/// <summary>
+	/// Tests if the api call works as expected the first time around.
+	/// So the retry policy isn't used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_First_Call_Succeeds_AddOrReplaceFileToTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			firstCallSucceedsClient.AddOrReplaceFileToTransactionAsync(
+				documentFile,
+				"Transaction Id",
+				"File Id",
+				new FileUploadOptions());
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-			documentFile = new MemoryStream();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the first time around.
+	/// So the retry policy isn't used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_First_Call_Succeeds_CreateTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			firstCallSucceedsClient.CreateTransactionAsync(new Transaction());
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the first time around.
-		/// So the retry policy isn't used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_First_Call_Succeeds_AddOrReplaceFileMetaToTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				firstCallSucceedsClient.AddOrReplaceFileMetaToTransactionAsync(
-					new FileMeta(),
-					"Transaction Id",
-					"File Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the first time around.
+	/// So the retry policy isn't used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_First_Call_Succeeds_DeleteTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			firstCallSucceedsClient.DeleteTransactionAsync(
+				"Transaction Id",
+				new DeleteTransactionOptions());
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the first time around.
-		/// So the retry policy isn't used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_First_Call_Succeeds_AddOrReplaceFileToTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				firstCallSucceedsClient.AddOrReplaceFileToTransactionAsync(
-					documentFile,
-					"Transaction Id",
-					"File Id",
-					new FileUploadOptions());
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the first time around.
+	/// So the retry policy isn't used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_First_Call_Succeeds_GetDocumentAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			firstCallSucceedsClient.GetDocumentAsync(
+				"Transaction Id",
+				"File Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the first time around.
-		/// So the retry policy isn't used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_First_Call_Succeeds_CreateTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				firstCallSucceedsClient.CreateTransactionAsync(new Transaction());
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the first time around.
+	/// So the retry policy isn't used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_First_Call_Succeeds_GetReceiptAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			firstCallSucceedsClient.GetReceiptAsync("Transaction Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the first time around.
-		/// So the retry policy isn't used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_First_Call_Succeeds_DeleteTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				firstCallSucceedsClient.DeleteTransactionAsync(
-					"Transaction Id",
-					new DeleteTransactionOptions());
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the first time around.
+	/// So the retry policy isn't used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_First_Call_Succeeds_GetTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			firstCallSucceedsClient.GetTransactionAsync("transaction Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the first time around.
-		/// So the retry policy isn't used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_First_Call_Succeeds_GetDocumentAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				firstCallSucceedsClient.GetDocumentAsync(
-					"Transaction Id",
-					"File Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the first time around.
+	/// So the retry policy isn't used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_First_Call_Succeeds_GetTransactionResponseAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			firstCallSucceedsClient.GetTransactionResponseAsync("Transaction Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the first time around.
-		/// So the retry policy isn't used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_First_Call_Succeeds_GetReceiptAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				firstCallSucceedsClient.GetReceiptAsync("Transaction Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the third time around.
+	/// So the retry policy is used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_Third_Call_Succeeds_AddOrReplaceFileMetaToTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = ()
+			=> thirdCallSucceedsClient.AddOrReplaceFileMetaToTransactionAsync(
+				new FileMeta(),
+				"Transaction Id",
+				"File Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the first time around.
-		/// So the retry policy isn't used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_First_Call_Succeeds_GetTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				firstCallSucceedsClient.GetTransactionAsync("transaction Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the third time around.
+	/// So the retry policy is used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_Third_Call_Succeeds_AddOrReplaceFileToTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			thirdCallSucceedsClient.AddOrReplaceFileToTransactionAsync(
+				documentFile,
+				"Transaction Id",
+				"File Id",
+				new FileUploadOptions());
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the first time around.
-		/// So the retry policy isn't used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_First_Call_Succeeds_GetTransactionResponseAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				firstCallSucceedsClient.GetTransactionResponseAsync("Transaction Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the third time around.
+	/// So the retry policy is used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_Third_Call_Succeeds_CreateTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			thirdCallSucceedsClient.CreateTransactionAsync(new Transaction());
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the third time around.
-		/// So the retry policy is used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_Third_Call_Succeeds_AddOrReplaceFileMetaToTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = ()
-				=> thirdCallSucceedsClient.AddOrReplaceFileMetaToTransactionAsync(
-					new FileMeta(),
-					"Transaction Id",
-					"File Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the third time around.
+	/// So the retry policy is used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_Third_Call_Succeeds_DeleteTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			thirdCallSucceedsClient.DeleteTransactionAsync(
+				"Transaction Id",
+				new DeleteTransactionOptions());
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the third time around.
-		/// So the retry policy is used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_Third_Call_Succeeds_AddOrReplaceFileToTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				thirdCallSucceedsClient.AddOrReplaceFileToTransactionAsync(
-					documentFile,
-					"Transaction Id",
-					"File Id",
-					new FileUploadOptions());
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the third time around.
+	/// So the retry policy is used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_Third_Call_Succeeds_GetDocumentAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = ()	=>
+			thirdCallSucceedsClient.GetDocumentAsync(
+				"Transaction Id",
+				"File Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the third time around.
-		/// So the retry policy is used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_Third_Call_Succeeds_CreateTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				thirdCallSucceedsClient.CreateTransactionAsync(new Transaction());
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the third time around.
+	/// So the retry policy is used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_Third_Call_Succeeds_GetReceiptAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			thirdCallSucceedsClient.GetReceiptAsync("Transaction Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the third time around.
-		/// So the retry policy is used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_Third_Call_Succeeds_DeleteTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				thirdCallSucceedsClient.DeleteTransactionAsync(
-					"Transaction Id",
-					new DeleteTransactionOptions());
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the third time around.
+	/// So the retry policy is used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_Third_Call_Succeeds_GetTransactionAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			thirdCallSucceedsClient.GetTransactionAsync("transaction Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the third time around.
-		/// So the retry policy is used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_Third_Call_Succeeds_GetDocumentAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = ()	=>
-				thirdCallSucceedsClient.GetDocumentAsync(
-					"Transaction Id",
-					"File Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call works as expected the third time around.
+	/// So the retry policy is used and no exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_Third_Call_Succeeds_GetTransactionResponseAsync_Should_Not_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			thirdCallSucceedsClient.GetTransactionResponseAsync("Transaction Id");
+		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the third time around.
-		/// So the retry policy is used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_Third_Call_Succeeds_GetReceiptAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				thirdCallSucceedsClient.GetReceiptAsync("Transaction Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call fails as expected the fourth time around.
+	/// So the retry policy is used and a exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_All_Calls_Fail_AddOrReplaceFileMetaToTransactionAsync_Should_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			allCallsFailClient.AddOrReplaceFileMetaToTransactionAsync(
+				new FileMeta(),
+				"Transaction Id",
+				"File Id");
+		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the third time around.
-		/// So the retry policy is used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_Third_Call_Succeeds_GetTransactionAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				thirdCallSucceedsClient.GetTransactionAsync("transaction Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call fails as expected the fourth time around.
+	/// So the retry policy is used and a exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_All_Calls_Fail_AddOrReplaceFileToTransactionAsync_Should_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			allCallsFailClient.AddOrReplaceFileToTransactionAsync(
+				new MemoryStream(),
+				"Transaction Id",
+				"File Id",
+				new FileUploadOptions());
+		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call works as expected the third time around.
-		/// So the retry policy is used and no exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_Third_Call_Succeeds_GetTransactionResponseAsync_Should_Not_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				thirdCallSucceedsClient.GetTransactionResponseAsync("Transaction Id");
-			apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call fails as expected the fourth time around.
+	/// So the retry policy is used and a exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_All_Calls_Fail_CreateTransactionAsync_Should_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			allCallsFailClient.CreateTransactionAsync(new Transaction());
+		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call fails as expected the fourth time around.
-		/// So the retry policy is used and a exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_All_Calls_Fail_AddOrReplaceFileMetaToTransactionAsync_Should_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				allCallsFailClient.AddOrReplaceFileMetaToTransactionAsync(
-					new FileMeta(),
-					"Transaction Id",
-					"File Id");
-			apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call fails as expected the fourth time around.
+	/// So the retry policy is used and a exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_All_Calls_Fail_DeleteTransactionAsync_Should_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			allCallsFailClient.DeleteTransactionAsync(
+				"Transaction Id",
+				new DeleteTransactionOptions());
+		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call fails as expected the fourth time around.
-		/// So the retry policy is used and a exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_All_Calls_Fail_AddOrReplaceFileToTransactionAsync_Should_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				allCallsFailClient.AddOrReplaceFileToTransactionAsync(
-					new MemoryStream(),
-					"Transaction Id",
-					"File Id",
-					new FileUploadOptions());
-			apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call fails as expected the fourth time around.
+	/// So the retry policy is used and a exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_All_Calls_Fails_GetDocumentAsync_Should_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			allCallsFailClient.GetDocumentAsync(
+				"Transaction Id",
+				"File Id");
+		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call fails as expected the fourth time around.
-		/// So the retry policy is used and a exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_All_Calls_Fail_CreateTransactionAsync_Should_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				allCallsFailClient.CreateTransactionAsync(new Transaction());
-			apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call fails as expected the fourth time around.
+	/// So the retry policy is used and a exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_All_Calls_Fail_GetReceiptAsync_Should_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			allCallsFailClient.GetReceiptAsync("Transaction Id");
+		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call fails as expected the fourth time around.
-		/// So the retry policy is used and a exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_All_Calls_Fail_DeleteTransactionAsync_Should_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				allCallsFailClient.DeleteTransactionAsync(
-					"Transaction Id",
-					new DeleteTransactionOptions());
-			apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call fails as expected the fourth time around.
+	/// So the retry policy is used and a exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_All_Calls_Fail_GetTransactionAsync_Should_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			allCallsFailClient.GetTransactionAsync("transaction Id");
+		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call fails as expected the fourth time around.
-		/// So the retry policy is used and a exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_All_Calls_Fails_GetDocumentAsync_Should_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				allCallsFailClient.GetDocumentAsync(
-					"Transaction Id",
-					"File Id");
-			apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Tests if the api call fails as expected the fourth time around.
+	/// So the retry policy is used and a exception is thrown.
+	/// </summary>
+	[Fact]
+	public void When_All_Calls_Fail_GetTransactionResponseAsync_Should_Throw_Exception()
+	{
+		Func<Task> apiCall = () =>
+			allCallsFailClient.GetTransactionResponseAsync("Transaction Id");
+		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
+	}
 
-		/// <summary>
-		/// Tests if the api call fails as expected the fourth time around.
-		/// So the retry policy is used and a exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_All_Calls_Fail_GetReceiptAsync_Should_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				allCallsFailClient.GetReceiptAsync("Transaction Id");
-			apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
 
-		/// <summary>
-		/// Tests if the api call fails as expected the fourth time around.
-		/// So the retry policy is used and a exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_All_Calls_Fail_GetTransactionAsync_Should_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				allCallsFailClient.GetTransactionAsync("transaction Id");
-			apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
-		}
+	/// <summary>
+	/// Disposes of the objects in the <see cref="SignhostApiRetryClientTests"/> class,
+	/// that implement IDisposable.
+	/// </summary>
+	/// <param name="disposing">If set to <c>true</c> then the object is being disposed from a call to Dispose();
+	/// <c>false</c> if it is from a finalizer / destructor.</param>
+	protected virtual void Dispose(bool disposing)
+	{
+		firstCallSucceedsClient.Dispose();
+		thirdCallSucceedsClient.Dispose();
+		allCallsFailClient.Dispose();
 
-		/// <summary>
-		/// Tests if the api call fails as expected the fourth time around.
-		/// So the retry policy is used and a exception is thrown.
-		/// </summary>
-		[Fact]
-		public void When_All_Calls_Fail_GetTransactionResponseAsync_Should_Throw_Exception()
-		{
-			Func<Task> apiCall = () =>
-				allCallsFailClient.GetTransactionResponseAsync("Transaction Id");
-			apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
-		}
+		documentFile.Dispose();
+	}
 
-		/// <inheritdoc/>
-		public void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
+	private HttpMessageHandler SetupMockedHandler(
+		HttpStatusCode firstStatus,
+		HttpStatusCode secondStatus,
+		HttpStatusCode thirdStatus,
+		HttpStatusCode fourthStatus)
+	{
+		var mockHandler = new Mock<HttpMessageHandler>();
+		mockHandler
+			.Protected()
+			.SetupSequence<Task<HttpResponseMessage>>(
+				"SendAsync",
+				ItExpr.IsAny<HttpRequestMessage>(),
+				ItExpr.IsAny<CancellationToken>())
+			.ReturnsAsync(new HttpResponseMessage(statusCode: firstStatus))
+			.ReturnsAsync(new HttpResponseMessage(statusCode: secondStatus))
+			.ReturnsAsync(new HttpResponseMessage(statusCode: thirdStatus))
+			.ReturnsAsync(new HttpResponseMessage(statusCode: fourthStatus));
 
-		/// <summary>
-		/// Disposes of the objects in the <see cref="SignhostApiRetryClientTests"/> class,
-		/// that implement IDisposable.
-		/// </summary>
-		/// <param name="disposing">If set to <c>true</c> then the object is being disposed from a call to Dispose();
-		/// <c>false</c> if it is from a finalizer / destructor.</param>
-		protected virtual void Dispose(bool disposing)
-		{
-			firstCallSucceedsClient.Dispose();
-			thirdCallSucceedsClient.Dispose();
-			allCallsFailClient.Dispose();
-
-			documentFile.Dispose();
-		}
-
-		private HttpMessageHandler SetupMockedHandler(
-			HttpStatusCode firstStatus,
-			HttpStatusCode secondStatus,
-			HttpStatusCode thirdStatus,
-			HttpStatusCode fourthStatus)
-		{
-			var mockHandler = new Mock<HttpMessageHandler>();
-			mockHandler
-				.Protected()
-				.SetupSequence<Task<HttpResponseMessage>>(
-					"SendAsync",
-					ItExpr.IsAny<HttpRequestMessage>(),
-					ItExpr.IsAny<CancellationToken>())
-				.ReturnsAsync(new HttpResponseMessage(statusCode: firstStatus))
-				.ReturnsAsync(new HttpResponseMessage(statusCode: secondStatus))
-				.ReturnsAsync(new HttpResponseMessage(statusCode: thirdStatus))
-				.ReturnsAsync(new HttpResponseMessage(statusCode: fourthStatus));
-
-			return mockHandler.Object;
-		}
+		return mockHandler.Object;
 	}
 }

--- a/src/Signhost.APIClient.Tests/SignhostApiRetryClientTests.cs
+++ b/src/Signhost.APIClient.Tests/SignhostApiRetryClientTests.cs
@@ -346,7 +346,7 @@ namespace SignhostAPIRetryClient.Tests
 		/// Tests if the api call fails as expected the fourth time around.
 		/// So the retry policy is used and a exception is thrown.
 		/// </summary>
-		[Fact(Skip = "Current method of the base library hasn't implemented SignhostRestApiClientException yet.")]
+		[Fact]
 		public void When_All_Calls_Fails_GetDocumentAsync_Should_Throw_Exception()
 		{
 			Func<Task> apiCall = () =>
@@ -360,7 +360,7 @@ namespace SignhostAPIRetryClient.Tests
 		/// Tests if the api call fails as expected the fourth time around.
 		/// So the retry policy is used and a exception is thrown.
 		/// </summary>
-		[Fact(Skip = "Current method of the base library hasn't implemented SignhostRestApiClientException yet.")]
+		[Fact]
 		public void When_All_Calls_Fail_GetReceiptAsync_Should_Throw_Exception()
 		{
 			Func<Task> apiCall = () =>

--- a/src/Signhost.APIClient.Tests/SignhostApiRetryClientTests.cs
+++ b/src/Signhost.APIClient.Tests/SignhostApiRetryClientTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.IO;
 using System.Net;
@@ -109,8 +108,8 @@ public class SignhostApiRetryClientTests
 	[Fact]
 	public void When_First_Call_Succeeds_CreateTransactionAsync_Should_Not_Throw_Exception()
 	{
-		Func<Task> apiCall = () =>
-			firstCallSucceedsClient.CreateTransactionAsync(new Transaction());
+		Func<Task> apiCall = () => firstCallSucceedsClient
+			.CreateTransactionAsync(new CreateTransactionRequest());
 		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
 	}
 
@@ -216,8 +215,8 @@ public class SignhostApiRetryClientTests
 	[Fact]
 	public void When_Third_Call_Succeeds_CreateTransactionAsync_Should_Not_Throw_Exception()
 	{
-		Func<Task> apiCall = () =>
-			thirdCallSucceedsClient.CreateTransactionAsync(new Transaction());
+		Func<Task> apiCall = () => thirdCallSucceedsClient
+			.CreateTransactionAsync(new CreateTransactionRequest());
 		apiCall.Should().NotThrowAsync<SignhostRestApiClientException>();
 	}
 
@@ -323,8 +322,8 @@ public class SignhostApiRetryClientTests
 	[Fact]
 	public void When_All_Calls_Fail_CreateTransactionAsync_Should_Throw_Exception()
 	{
-		Func<Task> apiCall = () =>
-			allCallsFailClient.CreateTransactionAsync(new Transaction());
+		Func<Task> apiCall = () => allCallsFailClient
+			.CreateTransactionAsync(new CreateTransactionRequest());
 		apiCall.Should().ThrowAsync<SignhostRestApiClientException>();
 	}
 

--- a/src/Signhost.APIClient/Rest/Polly/SignHostAPIRetryClient.cs
+++ b/src/Signhost.APIClient/Rest/Polly/SignHostAPIRetryClient.cs
@@ -11,44 +11,44 @@ using Signhost.APIClient.Rest.ErrorHandling;
 namespace Signhost.APIClient.Rest.Polly
 {
 	/// <summary>
-	/// Implements the <see cref="ISignHostApiClient"/> interface which provides
+	/// Implements the <see cref="ISignhostApiClient"/> interface which provides
 	/// a signhost api client implementation.
 	/// </summary>
-	public class SignHostApiRetryClient
-		: ISignHostApiClient
+	public class SignhostApiRetryClient
+		: ISignhostApiClient
 		, IDisposable
 	{
-		private readonly SignHostApiClient client;
+		private readonly SignhostApiClient client;
 		private readonly AsyncPolicy retryPolicy;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="SignHostApiRetryClient"/> class.
+		/// Initializes a new instance of the <see cref="SignhostApiRetryClient"/> class.
 		/// This client has a built-in retry mechanism.
-		/// Set your usertoken and APPKey by creating a <see cref="SignHostApiClientSettings"/>.
+		/// Set your usertoken and APPKey by creating a <see cref="SignhostApiClientSettings"/>.
 		/// </summary>
-		/// <param name="settings"><see cref="SignHostApiClientSettings"/>.</param>
+		/// <param name="settings"><see cref="SignhostApiClientSettings"/>.</param>
 		/// <param name="policy">An <see cref="AsyncPolicy"/> to use instead of the default.</param>
-		public SignHostApiRetryClient(
-			ISignHostApiClientSettings settings,
+		public SignhostApiRetryClient(
+			ISignhostApiClientSettings settings,
 			AsyncPolicy? policy = null)
 			: this(settings, new HttpClient(), policy)
 		{
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="SignHostApiRetryClient"/> class.
+		/// Initializes a new instance of the <see cref="SignhostApiRetryClient"/> class.
 		/// This client has a built-in retry mechanism.
-		/// Set your usertoken and APPKey by creating a <see cref="SignHostApiClientSettings"/>.
+		/// Set your usertoken and APPKey by creating a <see cref="SignhostApiClientSettings"/>.
 		/// </summary>
-		/// <param name="settings"><see cref="SignHostApiClientSettings"/>.</param>
+		/// <param name="settings"><see cref="SignhostApiClientSettings"/>.</param>
 		/// <param name="httpClient"><see cref="HttpClient"/> to use for all http calls.</param>
 		/// <param name="policy">An <see cref="AsyncPolicy"/> to use instead of the default.</param>
-		public SignHostApiRetryClient(
-			ISignHostApiClientSettings settings,
+		public SignhostApiRetryClient(
+			ISignhostApiClientSettings settings,
 			HttpClient httpClient,
 			AsyncPolicy? policy = null)
 		{
-			client = new SignHostApiClient(settings, httpClient);
+			client = new SignhostApiClient(settings, httpClient);
 
 			if (policy is null) {
 				retryPolicy = GetDefaultPolicy();

--- a/src/Signhost.APIClient/Rest/Polly/SignHostAPIRetryClient.cs
+++ b/src/Signhost.APIClient/Rest/Polly/SignHostAPIRetryClient.cs
@@ -8,323 +8,322 @@ using Polly;
 using Signhost.APIClient.Rest.DataObjects;
 using Signhost.APIClient.Rest.ErrorHandling;
 
-namespace Signhost.APIClient.Rest.Polly
+namespace Signhost.APIClient.Rest.Polly;
+
+/// <summary>
+/// Implements the <see cref="ISignhostApiClient"/> interface which provides
+/// a signhost api client implementation.
+/// </summary>
+public class SignhostApiRetryClient
+	: ISignhostApiClient
+	, IDisposable
 {
+	private readonly SignhostApiClient client;
+	private readonly AsyncPolicy retryPolicy;
+
 	/// <summary>
-	/// Implements the <see cref="ISignhostApiClient"/> interface which provides
-	/// a signhost api client implementation.
+	/// Initializes a new instance of the <see cref="SignhostApiRetryClient"/> class.
+	/// This client has a built-in retry mechanism.
+	/// Set your usertoken and APPKey by creating a <see cref="SignhostApiClientSettings"/>.
 	/// </summary>
-	public class SignhostApiRetryClient
-		: ISignhostApiClient
-		, IDisposable
+	/// <param name="settings"><see cref="SignhostApiClientSettings"/>.</param>
+	/// <param name="policy">An <see cref="AsyncPolicy"/> to use instead of the default.</param>
+	public SignhostApiRetryClient(
+		ISignhostApiClientSettings settings,
+		AsyncPolicy? policy = null)
+		: this(settings, new HttpClient(), policy)
 	{
-		private readonly SignhostApiClient client;
-		private readonly AsyncPolicy retryPolicy;
+	}
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="SignhostApiRetryClient"/> class.
-		/// This client has a built-in retry mechanism.
-		/// Set your usertoken and APPKey by creating a <see cref="SignhostApiClientSettings"/>.
-		/// </summary>
-		/// <param name="settings"><see cref="SignhostApiClientSettings"/>.</param>
-		/// <param name="policy">An <see cref="AsyncPolicy"/> to use instead of the default.</param>
-		public SignhostApiRetryClient(
-			ISignhostApiClientSettings settings,
-			AsyncPolicy? policy = null)
-			: this(settings, new HttpClient(), policy)
-		{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SignhostApiRetryClient"/> class.
+	/// This client has a built-in retry mechanism.
+	/// Set your usertoken and APPKey by creating a <see cref="SignhostApiClientSettings"/>.
+	/// </summary>
+	/// <param name="settings"><see cref="SignhostApiClientSettings"/>.</param>
+	/// <param name="httpClient"><see cref="HttpClient"/> to use for all http calls.</param>
+	/// <param name="policy">An <see cref="AsyncPolicy"/> to use instead of the default.</param>
+	public SignhostApiRetryClient(
+		ISignhostApiClientSettings settings,
+		HttpClient httpClient,
+		AsyncPolicy? policy = null)
+	{
+		client = new SignhostApiClient(settings, httpClient);
+
+		if (policy is null) {
+			retryPolicy = GetDefaultPolicy();
 		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="SignhostApiRetryClient"/> class.
-		/// This client has a built-in retry mechanism.
-		/// Set your usertoken and APPKey by creating a <see cref="SignhostApiClientSettings"/>.
-		/// </summary>
-		/// <param name="settings"><see cref="SignhostApiClientSettings"/>.</param>
-		/// <param name="httpClient"><see cref="HttpClient"/> to use for all http calls.</param>
-		/// <param name="policy">An <see cref="AsyncPolicy"/> to use instead of the default.</param>
-		public SignhostApiRetryClient(
-			ISignhostApiClientSettings settings,
-			HttpClient httpClient,
-			AsyncPolicy? policy = null)
-		{
-			client = new SignhostApiClient(settings, httpClient);
-
-			if (policy is null) {
-				retryPolicy = GetDefaultPolicy();
-			}
-			else {
-				retryPolicy = policy;
-			}
+		else {
+			retryPolicy = policy;
 		}
+	}
 
-		/// <inheritdoc />
-		public async Task AddOrReplaceFileMetaToTransactionAsync(
-			FileMeta fileMeta,
-			string transactionId,
-			string fileId)
-			=> await AddOrReplaceFileMetaToTransactionAsync(
-				fileMeta,
-				transactionId,
-				fileId,
-				default);
+	/// <inheritdoc />
+	public async Task AddOrReplaceFileMetaToTransactionAsync(
+		FileMeta fileMeta,
+		string transactionId,
+		string fileId)
+		=> await AddOrReplaceFileMetaToTransactionAsync(
+			fileMeta,
+			transactionId,
+			fileId,
+			default);
 
-		/// <inheritdoc />
-		public async Task AddOrReplaceFileMetaToTransactionAsync(
-			FileMeta fileMeta,
-			string transactionId,
-			string fileId,
-			CancellationToken cancellationToken = default)
-		{
-			await retryPolicy
-				.ExecuteAsync(
-					ct => client.AddOrReplaceFileMetaToTransactionAsync(
-						fileMeta,
-						transactionId,
-						fileId,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public async Task AddOrReplaceFileToTransactionAsync(
-			Stream fileStream,
-			string transactionId,
-			string fileId,
-			FileUploadOptions uploadOptions)
-			=> await AddOrReplaceFileToTransactionAsync(
-				fileStream,
-				transactionId,
-				fileId,
-				uploadOptions,
-				default);
-
-		/// <inheritdoc />
-		public async Task AddOrReplaceFileToTransactionAsync(
-			Stream fileStream,
-			string transactionId,
-			string fileId,
-			FileUploadOptions uploadOptions,
-			CancellationToken cancellationToken = default)
-		{
-			await retryPolicy
-				.ExecuteAsync(
-					ct => client.AddOrReplaceFileToTransactionAsync(
-						fileStream,
-						transactionId,
-						fileId,
-						uploadOptions,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public async Task AddOrReplaceFileToTransactionAsync(
-			string filePath,
-			string transactionId,
-			string fileId,
-			FileUploadOptions uploadOptions)
-			=> await AddOrReplaceFileToTransactionAsync(
-				filePath,
-				transactionId,
-				fileId,
-				uploadOptions,
-				default);
-
-		/// <inheritdoc />
-		public async Task AddOrReplaceFileToTransactionAsync(
-			string filePath,
-			string transactionId,
-			string fileId,
-			FileUploadOptions uploadOptions,
-			CancellationToken cancellationToken = default)
-		{
-			await retryPolicy
-				.ExecuteAsync(
-					ct => client.AddOrReplaceFileToTransactionAsync(
-						filePath,
-						transactionId,
-						fileId,
-						uploadOptions,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public async Task<Transaction> CreateTransactionAsync(
-			Transaction transaction)
-			=> await CreateTransactionAsync(transaction, default);
-
-		/// <inheritdoc />
-		public async Task<Transaction> CreateTransactionAsync(
-			Transaction transaction,
-			CancellationToken cancellationToken = default)
-		{
-			return await retryPolicy
-				.ExecuteAsync(
-					ct => client.CreateTransactionAsync(
-						transaction,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public async Task DeleteTransactionAsync(
-			string transactionId,
-			CancellationToken cancellationToken = default)
-			=> await DeleteTransactionAsync(
-				transactionId,
-				default,
+	/// <inheritdoc />
+	public async Task AddOrReplaceFileMetaToTransactionAsync(
+		FileMeta fileMeta,
+		string transactionId,
+		string fileId,
+		CancellationToken cancellationToken = default)
+	{
+		await retryPolicy
+			.ExecuteAsync(
+				ct => client.AddOrReplaceFileMetaToTransactionAsync(
+					fileMeta,
+					transactionId,
+					fileId,
+					ct),
 				cancellationToken);
+	}
 
-		/// <inheritdoc />
-		public async Task DeleteTransactionAsync(
-			string transactionId,
-			DeleteTransactionOptions options)
-			=> await DeleteTransactionAsync(
-				transactionId,
-				options,
-				default);
+	/// <inheritdoc />
+	public async Task AddOrReplaceFileToTransactionAsync(
+		Stream fileStream,
+		string transactionId,
+		string fileId,
+		FileUploadOptions uploadOptions)
+		=> await AddOrReplaceFileToTransactionAsync(
+			fileStream,
+			transactionId,
+			fileId,
+			uploadOptions,
+			default);
 
-		/// <inheritdoc />
-		public async Task DeleteTransactionAsync(
-			string transactionId,
-			DeleteTransactionOptions? options = null,
-			CancellationToken cancellationToken = default)
-		{
-			await retryPolicy
-				.ExecuteAsync(
-					ct => client.DeleteTransactionAsync(
-						transactionId,
-						options,
-						ct),
-					cancellationToken);
+	/// <inheritdoc />
+	public async Task AddOrReplaceFileToTransactionAsync(
+		Stream fileStream,
+		string transactionId,
+		string fileId,
+		FileUploadOptions uploadOptions,
+		CancellationToken cancellationToken = default)
+	{
+		await retryPolicy
+			.ExecuteAsync(
+				ct => client.AddOrReplaceFileToTransactionAsync(
+					fileStream,
+					transactionId,
+					fileId,
+					uploadOptions,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task AddOrReplaceFileToTransactionAsync(
+		string filePath,
+		string transactionId,
+		string fileId,
+		FileUploadOptions uploadOptions)
+		=> await AddOrReplaceFileToTransactionAsync(
+			filePath,
+			transactionId,
+			fileId,
+			uploadOptions,
+			default);
+
+	/// <inheritdoc />
+	public async Task AddOrReplaceFileToTransactionAsync(
+		string filePath,
+		string transactionId,
+		string fileId,
+		FileUploadOptions uploadOptions,
+		CancellationToken cancellationToken = default)
+	{
+		await retryPolicy
+			.ExecuteAsync(
+				ct => client.AddOrReplaceFileToTransactionAsync(
+					filePath,
+					transactionId,
+					fileId,
+					uploadOptions,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task<Transaction> CreateTransactionAsync(
+		Transaction transaction)
+		=> await CreateTransactionAsync(transaction, default);
+
+	/// <inheritdoc />
+	public async Task<Transaction> CreateTransactionAsync(
+		Transaction transaction,
+		CancellationToken cancellationToken = default)
+	{
+		return await retryPolicy
+			.ExecuteAsync(
+				ct => client.CreateTransactionAsync(
+					transaction,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task DeleteTransactionAsync(
+		string transactionId,
+		CancellationToken cancellationToken = default)
+		=> await DeleteTransactionAsync(
+			transactionId,
+			default,
+			cancellationToken);
+
+	/// <inheritdoc />
+	public async Task DeleteTransactionAsync(
+		string transactionId,
+		DeleteTransactionOptions options)
+		=> await DeleteTransactionAsync(
+			transactionId,
+			options,
+			default);
+
+	/// <inheritdoc />
+	public async Task DeleteTransactionAsync(
+		string transactionId,
+		DeleteTransactionOptions? options = null,
+		CancellationToken cancellationToken = default)
+	{
+		await retryPolicy
+			.ExecuteAsync(
+				ct => client.DeleteTransactionAsync(
+					transactionId,
+					options,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task<Stream> GetDocumentAsync(
+		string transactionId,
+		string fileId)
+		=> await GetDocumentAsync(transactionId, fileId, default);
+
+	/// <inheritdoc />
+	public async Task<Stream> GetDocumentAsync(
+		string transactionId,
+		string fileId,
+		CancellationToken cancellationToken = default)
+	{
+		return await retryPolicy
+			.ExecuteAsync(
+				ct => client.GetDocumentAsync(
+					transactionId,
+					fileId,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task<Stream> GetReceiptAsync(string transactionId)
+		=> await GetReceiptAsync(transactionId, default);
+
+	/// <inheritdoc />
+	public async Task<Stream> GetReceiptAsync(
+		string transactionId,
+		CancellationToken cancellationToken = default)
+	{
+		return await retryPolicy
+			.ExecuteAsync(
+				ct => client.GetReceiptAsync(
+					transactionId,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task<Transaction> GetTransactionAsync(string transactionId)
+		=> await GetTransactionAsync(transactionId, default);
+
+	/// <inheritdoc />
+	public async Task<Transaction> GetTransactionAsync(
+		string transactionId,
+		CancellationToken cancellationToken = default)
+	{
+		return await retryPolicy
+			.ExecuteAsync(
+				ct => client.GetTransactionAsync(
+					transactionId,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task<ApiResponse<Transaction>> GetTransactionResponseAsync(
+		string transactionId)
+		=> await GetTransactionResponseAsync(transactionId, default);
+
+	/// <inheritdoc />
+	public async Task<ApiResponse<Transaction>> GetTransactionResponseAsync(
+		string transactionId,
+		CancellationToken cancellationToken = default)
+	{
+		return await retryPolicy
+			.ExecuteAsync(
+				ct => client.GetTransactionResponseAsync(
+					transactionId,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task StartTransactionAsync(
+		string transactionId)
+		=> await StartTransactionAsync(transactionId, default);
+
+	/// <inheritdoc />
+	public async Task StartTransactionAsync(
+		string transactionId,
+		CancellationToken cancellationToken = default)
+	{
+		await retryPolicy
+			.ExecuteAsync(
+				ct => client.StartTransactionAsync(
+					transactionId,
+					ct),
+				cancellationToken);
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
+
+	/// <summary>
+	/// Disposes the instance.
+	/// </summary>
+	/// <param name="disposing">Is <see cref="Dispose"/> callled.</param>
+	protected virtual void Dispose(bool disposing)
+	{
+		if (disposing) {
+			client?.Dispose();
 		}
+	}
 
-		/// <inheritdoc />
-		public async Task<Stream> GetDocumentAsync(
-			string transactionId,
-			string fileId)
-			=> await GetDocumentAsync(transactionId, fileId, default);
+	private static AsyncPolicy GetDefaultPolicy()
+	{
+		return Policy
+			.Handle<SignhostRestApiClientException>(ex =>
+				!(ex is BadAuthorizationException) &&
+				!(ex is BadRequestException) &&
+				!(ex is NotFoundException))
 
-		/// <inheritdoc />
-		public async Task<Stream> GetDocumentAsync(
-			string transactionId,
-			string fileId,
-			CancellationToken cancellationToken = default)
-		{
-			return await retryPolicy
-				.ExecuteAsync(
-					ct => client.GetDocumentAsync(
-						transactionId,
-						fileId,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public async Task<Stream> GetReceiptAsync(string transactionId)
-			=> await GetReceiptAsync(transactionId, default);
-
-		/// <inheritdoc />
-		public async Task<Stream> GetReceiptAsync(
-			string transactionId,
-			CancellationToken cancellationToken = default)
-		{
-			return await retryPolicy
-				.ExecuteAsync(
-					ct => client.GetReceiptAsync(
-						transactionId,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public async Task<Transaction> GetTransactionAsync(string transactionId)
-			=> await GetTransactionAsync(transactionId, default);
-
-		/// <inheritdoc />
-		public async Task<Transaction> GetTransactionAsync(
-			string transactionId,
-			CancellationToken cancellationToken = default)
-		{
-			return await retryPolicy
-				.ExecuteAsync(
-					ct => client.GetTransactionAsync(
-						transactionId,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public async Task<ApiResponse<Transaction>> GetTransactionResponseAsync(
-			string transactionId)
-			=> await GetTransactionResponseAsync(transactionId, default);
-
-		/// <inheritdoc />
-		public async Task<ApiResponse<Transaction>> GetTransactionResponseAsync(
-			string transactionId,
-			CancellationToken cancellationToken = default)
-		{
-			return await retryPolicy
-				.ExecuteAsync(
-					ct => client.GetTransactionResponseAsync(
-						transactionId,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public async Task StartTransactionAsync(
-			string transactionId)
-			=> await StartTransactionAsync(transactionId, default);
-
-		/// <inheritdoc />
-		public async Task StartTransactionAsync(
-			string transactionId,
-			CancellationToken cancellationToken = default)
-		{
-			await retryPolicy
-				.ExecuteAsync(
-					ct => client.StartTransactionAsync(
-						transactionId,
-						ct),
-					cancellationToken);
-		}
-
-		/// <inheritdoc/>
-		public void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
-		/// <summary>
-		/// Disposes the instance.
-		/// </summary>
-		/// <param name="disposing">Is <see cref="Dispose"/> callled.</param>
-		protected virtual void Dispose(bool disposing)
-		{
-			if (disposing) {
-				client?.Dispose();
-			}
-		}
-
-		private static AsyncPolicy GetDefaultPolicy()
-		{
-			return Policy
-				.Handle<SignhostRestApiClientException>(ex =>
-					!(ex is BadAuthorizationException) &&
-					!(ex is BadRequestException) &&
-					!(ex is NotFoundException))
-
-				// When an HttpClient times out it doesn't throw a TimeoutException like you'd expect.
-				// Instead it throws a TaskCanceledException, that's why we check the cancellation token.
-				.Or<TaskCanceledException>(ex => !ex.CancellationToken.IsCancellationRequested)
-				.WaitAndRetryAsync(
-					3,
-					retryAttempt =>
-						TimeSpan.FromMilliseconds(Math.Pow(10, retryAttempt)));
-		}
+			// When an HttpClient times out it doesn't throw a TimeoutException like you'd expect.
+			// Instead it throws a TaskCanceledException, that's why we check the cancellation token.
+			.Or<TaskCanceledException>(ex => !ex.CancellationToken.IsCancellationRequested)
+			.WaitAndRetryAsync(
+				3,
+				retryAttempt =>
+					TimeSpan.FromMilliseconds(Math.Pow(10, retryAttempt)));
 	}
 }

--- a/src/Signhost.APIClient/Rest/Polly/SignHostAPIRetryClient.cs
+++ b/src/Signhost.APIClient/Rest/Polly/SignHostAPIRetryClient.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -59,132 +58,66 @@ public class SignhostApiRetryClient
 	}
 
 	/// <inheritdoc />
-	public async Task AddOrReplaceFileMetaToTransactionAsync(
-		FileMeta fileMeta,
-		string transactionId,
-		string fileId)
-		=> await AddOrReplaceFileMetaToTransactionAsync(
-			fileMeta,
-			transactionId,
-			fileId,
-			default);
-
-	/// <inheritdoc />
-	public async Task AddOrReplaceFileMetaToTransactionAsync(
-		FileMeta fileMeta,
-		string transactionId,
-		string fileId,
-		CancellationToken cancellationToken = default)
-	{
-		await retryPolicy
-			.ExecuteAsync(
-				ct => client.AddOrReplaceFileMetaToTransactionAsync(
-					fileMeta,
-					transactionId,
-					fileId,
-					ct),
-				cancellationToken);
-	}
-
-	/// <inheritdoc />
-	public async Task AddOrReplaceFileToTransactionAsync(
-		Stream fileStream,
-		string transactionId,
-		string fileId,
-		FileUploadOptions uploadOptions)
-		=> await AddOrReplaceFileToTransactionAsync(
-			fileStream,
-			transactionId,
-			fileId,
-			uploadOptions,
-			default);
-
-	/// <inheritdoc />
-	public async Task AddOrReplaceFileToTransactionAsync(
-		Stream fileStream,
-		string transactionId,
-		string fileId,
-		FileUploadOptions uploadOptions,
-		CancellationToken cancellationToken = default)
-	{
-		await retryPolicy
-			.ExecuteAsync(
-				ct => client.AddOrReplaceFileToTransactionAsync(
-					fileStream,
-					transactionId,
-					fileId,
-					uploadOptions,
-					ct),
-				cancellationToken);
-	}
-
-	/// <inheritdoc />
-	public async Task AddOrReplaceFileToTransactionAsync(
-		string filePath,
-		string transactionId,
-		string fileId,
-		FileUploadOptions uploadOptions)
-		=> await AddOrReplaceFileToTransactionAsync(
-			filePath,
-			transactionId,
-			fileId,
-			uploadOptions,
-			default);
-
-	/// <inheritdoc />
-	public async Task AddOrReplaceFileToTransactionAsync(
-		string filePath,
-		string transactionId,
-		string fileId,
-		FileUploadOptions uploadOptions,
-		CancellationToken cancellationToken = default)
-	{
-		await retryPolicy
-			.ExecuteAsync(
-				ct => client.AddOrReplaceFileToTransactionAsync(
-					filePath,
-					transactionId,
-					fileId,
-					uploadOptions,
-					ct),
-				cancellationToken);
-	}
-
-	/// <inheritdoc />
 	public async Task<Transaction> CreateTransactionAsync(
-		Transaction transaction)
-		=> await CreateTransactionAsync(transaction, default);
-
-	/// <inheritdoc />
-	public async Task<Transaction> CreateTransactionAsync(
-		Transaction transaction,
+		CreateTransactionRequest request,
 		CancellationToken cancellationToken = default)
 	{
-		return await retryPolicy
-			.ExecuteAsync(
-				ct => client.CreateTransactionAsync(
-					transaction,
-					ct),
-				cancellationToken);
-	}
-
-	/// <inheritdoc />
-	public async Task DeleteTransactionAsync(
-		string transactionId,
-		CancellationToken cancellationToken = default)
-		=> await DeleteTransactionAsync(
-			transactionId,
-			default,
+		return await retryPolicy.ExecuteAsync(
+			ct => client.CreateTransactionAsync(request, ct),
 			cancellationToken);
+	}
 
 	/// <inheritdoc />
-	public async Task DeleteTransactionAsync(
+	public async Task AddOrReplaceFileMetaToTransactionAsync(
+		FileMeta fileMeta,
 		string transactionId,
-		DeleteTransactionOptions options)
-		=> await DeleteTransactionAsync(
-			transactionId,
-			options,
-			default);
+		string fileId,
+		CancellationToken cancellationToken = default)
+	{
+		await retryPolicy.ExecuteAsync(
+			ct => client.AddOrReplaceFileMetaToTransactionAsync(
+				fileMeta,
+				transactionId,
+				fileId,
+				ct),
+			cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task AddOrReplaceFileToTransactionAsync(
+		Stream fileStream,
+		string transactionId,
+		string fileId,
+		FileUploadOptions? uploadOptions,
+		CancellationToken cancellationToken = default)
+	{
+		await retryPolicy.ExecuteAsync(
+			ct => client.AddOrReplaceFileToTransactionAsync(
+				fileStream,
+				transactionId,
+				fileId,
+				uploadOptions,
+				ct),
+			cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task AddOrReplaceFileToTransactionAsync(
+		string filePath,
+		string transactionId,
+		string fileId,
+		FileUploadOptions? uploadOptions,
+		CancellationToken cancellationToken = default)
+	{
+		await retryPolicy.ExecuteAsync(
+			ct => client.AddOrReplaceFileToTransactionAsync(
+				filePath,
+				transactionId,
+				fileId,
+				uploadOptions,
+				ct),
+			cancellationToken);
+	}
 
 	/// <inheritdoc />
 	public async Task DeleteTransactionAsync(
@@ -192,20 +125,10 @@ public class SignhostApiRetryClient
 		DeleteTransactionOptions? options = null,
 		CancellationToken cancellationToken = default)
 	{
-		await retryPolicy
-			.ExecuteAsync(
-				ct => client.DeleteTransactionAsync(
-					transactionId,
-					options,
-					ct),
-				cancellationToken);
+		await retryPolicy.ExecuteAsync(
+			ct => client.DeleteTransactionAsync(transactionId, options, ct),
+			cancellationToken);
 	}
-
-	/// <inheritdoc />
-	public async Task<Stream> GetDocumentAsync(
-		string transactionId,
-		string fileId)
-		=> await GetDocumentAsync(transactionId, fileId, default);
 
 	/// <inheritdoc />
 	public async Task<Stream> GetDocumentAsync(
@@ -213,83 +136,49 @@ public class SignhostApiRetryClient
 		string fileId,
 		CancellationToken cancellationToken = default)
 	{
-		return await retryPolicy
-			.ExecuteAsync(
-				ct => client.GetDocumentAsync(
-					transactionId,
-					fileId,
-					ct),
-				cancellationToken);
+		return await retryPolicy.ExecuteAsync(
+			ct => client.GetDocumentAsync(transactionId, fileId, ct),
+			cancellationToken);
 	}
-
-	/// <inheritdoc />
-	public async Task<Stream> GetReceiptAsync(string transactionId)
-		=> await GetReceiptAsync(transactionId, default);
 
 	/// <inheritdoc />
 	public async Task<Stream> GetReceiptAsync(
 		string transactionId,
 		CancellationToken cancellationToken = default)
 	{
-		return await retryPolicy
-			.ExecuteAsync(
-				ct => client.GetReceiptAsync(
-					transactionId,
-					ct),
-				cancellationToken);
+		return await retryPolicy.ExecuteAsync(
+			ct => client.GetReceiptAsync(transactionId, ct),
+			cancellationToken);
 	}
-
-	/// <inheritdoc />
-	public async Task<Transaction> GetTransactionAsync(string transactionId)
-		=> await GetTransactionAsync(transactionId, default);
 
 	/// <inheritdoc />
 	public async Task<Transaction> GetTransactionAsync(
 		string transactionId,
 		CancellationToken cancellationToken = default)
 	{
-		return await retryPolicy
-			.ExecuteAsync(
-				ct => client.GetTransactionAsync(
-					transactionId,
-					ct),
-				cancellationToken);
+		return await retryPolicy.ExecuteAsync(
+			ct => client.GetTransactionAsync(transactionId, ct),
+			cancellationToken);
 	}
-
-	/// <inheritdoc />
-	public async Task<ApiResponse<Transaction>> GetTransactionResponseAsync(
-		string transactionId)
-		=> await GetTransactionResponseAsync(transactionId, default);
 
 	/// <inheritdoc />
 	public async Task<ApiResponse<Transaction>> GetTransactionResponseAsync(
 		string transactionId,
 		CancellationToken cancellationToken = default)
 	{
-		return await retryPolicy
-			.ExecuteAsync(
-				ct => client.GetTransactionResponseAsync(
-					transactionId,
-					ct),
-				cancellationToken);
+		return await retryPolicy.ExecuteAsync(
+			ct => client.GetTransactionResponseAsync(transactionId, ct),
+			cancellationToken);
 	}
-
-	/// <inheritdoc />
-	public async Task StartTransactionAsync(
-		string transactionId)
-		=> await StartTransactionAsync(transactionId, default);
 
 	/// <inheritdoc />
 	public async Task StartTransactionAsync(
 		string transactionId,
 		CancellationToken cancellationToken = default)
 	{
-		await retryPolicy
-			.ExecuteAsync(
-				ct => client.StartTransactionAsync(
-					transactionId,
-					ct),
-				cancellationToken);
+		await retryPolicy.ExecuteAsync(
+			ct => client.StartTransactionAsync(transactionId, ct),
+			cancellationToken);
 	}
 
 	/// <inheritdoc/>
@@ -314,9 +203,9 @@ public class SignhostApiRetryClient
 	{
 		return Policy
 			.Handle<SignhostRestApiClientException>(ex =>
-				!(ex is BadAuthorizationException) &&
-				!(ex is BadRequestException) &&
-				!(ex is NotFoundException))
+				ex is not BadAuthorizationException &&
+				ex is not BadRequestException &&
+				ex is not NotFoundException)
 
 			// When an HttpClient times out it doesn't throw a TimeoutException like you'd expect.
 			// Instead it throws a TaskCanceledException, that's why we check the cancellation token.

--- a/src/Signhost.APIClient/Signhost.APIClient.csproj
+++ b/src/Signhost.APIClient/Signhost.APIClient.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup Label="Build">
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net462</TargetFrameworks>
+		<LangVersion>10</LangVersion>
 		<RootNamespace>Signhost.APIClient</RootNamespace>
 	</PropertyGroup>
 

--- a/src/Signhost.APIClient/Signhost.APIClient.csproj
+++ b/src/Signhost.APIClient/Signhost.APIClient.csproj
@@ -3,6 +3,7 @@
 		<TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net462</TargetFrameworks>
 		<LangVersion>10</LangVersion>
 		<RootNamespace>Signhost.APIClient</RootNamespace>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -45,6 +46,6 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Polly" Version="8.6.5" />
-		<PackageReference Include="EntrustSignhostClientLibrary" Version="4.3.0" />
+		<PackageReference Include="EntrustSignhostClientLibrary" Version="5.0.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request introduces significant updates to the .NET client library, primarily focused on upgrading to .NET 10, updating package dependencies, and standardizing naming conventions for consistency. The most important changes are grouped below:

**.NET Version and Project File Updates:**

* Upgraded target framework to .NET 10 in both `Signhost.APIClient` and `Signhost.APIClient.Tests` projects, and expanded supported frameworks to include net10.0, net9.0, net8.0, netstandard2.0, and net462 in `Signhost.APIClient.csproj`. [[1]](diffhunk://#diff-a7e2d82d92cd853ebe9bca1cb62b877e1c2ac86166e7e183148425393b765856L3-R4) [[2]](diffhunk://#diff-e283ec4259920e20e9c1d8b72b24b8ebdf37323cd0502aff85ee71163074f786L3-R3)
* Updated the NuGet publish workflow in `.github/workflows/publish_nuget_package.yml` to use .NET 10.
* Bumped package version to 5.0.0 and updated the referenced `EntrustSignhostClientLibrary` to version 5.0.0. [[1]](diffhunk://#diff-a7e2d82d92cd853ebe9bca1cb62b877e1c2ac86166e7e183148425393b765856L12-R13) [[2]](diffhunk://#diff-a7e2d82d92cd853ebe9bca1cb62b877e1c2ac86166e7e183148425393b765856L27-R26) [[3]](diffhunk://#diff-a7e2d82d92cd853ebe9bca1cb62b877e1c2ac86166e7e183148425393b765856L47-R46)

**Naming and Consistency Improvements:**

* Renamed all instances of `SignHostApiClientSettings`/`SignHostApiRetryClient` to `SignhostApiClientSettings`/`SignhostApiRetryClient` across source, test, and documentation files for consistency. [[1]](diffhunk://#diff-24e7df2daebb022836eba99b8e21fb4baf283653659bd44f87814c824b53ba71L11-R51) [[2]](diffhunk://#diff-5b506800a3ad0f3f85d12b50bf8b57ac6ef30a75c5a61dab8dab7eaf4af53f51L17-R29) [[3]](diffhunk://#diff-5b506800a3ad0f3f85d12b50bf8b57ac6ef30a75c5a61dab8dab7eaf4af53f51L39-R44) [[4]](diffhunk://#diff-5b506800a3ad0f3f85d12b50bf8b57ac6ef30a75c5a61dab8dab7eaf4af53f51L53-R53) [[5]](diffhunk://#diff-5b506800a3ad0f3f85d12b50bf8b57ac6ef30a75c5a61dab8dab7eaf4af53f51L62-R62) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R21)
* Updated code comments and XML documentation to reflect the new naming conventions.

**Testing Improvements:**

* Enabled previously skipped test cases in `SignhostApiRetryClientTests.cs` to ensure all retry and exception scenarios are now validated. [[1]](diffhunk://#diff-5b506800a3ad0f3f85d12b50bf8b57ac6ef30a75c5a61dab8dab7eaf4af53f51L349-R349) [[2]](diffhunk://#diff-5b506800a3ad0f3f85d12b50bf8b57ac6ef30a75c5a61dab8dab7eaf4af53f51L363-R363)