### PR TITLE
SIG-5191 Downgrade FluentAssertions version to 7.2.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "FluentAssertions"
+      ],
+      "allowedVersions": "<8.0.0"
+    }
   ]
 }

--- a/src/Signhost.APIClient.Tests/Signhost.APIClient.Tests.csproj
+++ b/src/Signhost.APIClient.Tests/Signhost.APIClient.Tests.csproj
@@ -8,7 +8,7 @@
 		<PackageReference Include="ConfigureAwait.Fody" Version="3.3.2">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="8.7.0" />
+		<PackageReference Include="FluentAssertions" Version="7.2.0" />
 		<PackageReference Include="Fody" Version="6.9.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
v8.* requires a license, also adjusts the renovate.json package rules to avoid future bump PRs.